### PR TITLE
Bot Moving cards from security and other bugfixes

### DIFF
--- a/Bot-Guide.md
+++ b/Bot-Guide.md
@@ -39,7 +39,7 @@ The position X is identified in the following way on the field:
 
 - **reveal top deck**: Reveal the top card of the opponent deck.
 
-- **trash top deck**: Trash the top card of the opponent deck.
+- **trash top deck X**: Trash the top X cards of the opponent deck.
 
 - **play reveal X**: Play card from the revealed cards at position X, starting from left.
 

--- a/ai/Bot.py
+++ b/ai/Bot.py
@@ -1020,14 +1020,18 @@ class Bot(ABC):
         await self.send_message(ws, f'[FIELD_UPDATE]≔【{card["name"]}】﹕ ➟ Deck Top')
         self.game['player2DeckField'].insert(0, card)
         self.logger.info(f"Put {card['uniqueCardNumber']} {card['name']} on top of deck.")
-    
-    async def trash_top_card_of_deck(self, ws):
-        await self.move_card(ws, 'myDeckField0', 'myTrash')
-        card = self.game['player2DeckField'].pop(0)
-        self.game['player2Trash'].insert(0, card)
-        await self.trashed_card_effect(ws, card)
+
+    async def trash_top_cards_of_deck(self, ws, n):
+        trashed_cards = []
+        for i in range(n):
+            if len(self.game['player2DeckField']) > 0:
+                await self.move_card(ws, 'myDeckField0', 'myTrash')
+                card = self.game['player2DeckField'].pop(0)
+                self.game['player2Trash'].insert(0, card)
+                trashed_cards.append(card)
+        await self.when_cards_are_trashed_from_deck(ws, trashed_cards)
         self.logger.info(f"Trashed {card['uniqueCardNumber']} {card['name']} from top of deck.")
-        return card
+        return trashed_cards
 
     async def set_memory_to(self, ws, value):
         self.logger.info(f'Set memory to {value}')
@@ -1197,5 +1201,9 @@ class Bot(ABC):
 
     @abstractmethod
     def collision_strategy(self):
+        pass
+
+    @abstractmethod
+    def when_cards_are_trashed_from_deck(self):
         pass
 

--- a/ai/Bot.py
+++ b/ai/Bot.py
@@ -966,13 +966,13 @@ class Bot(ABC):
         card_index = self.find_card_index_by_id_in_security(card_id)
         self.logger.info(f'Revealing security card at position {card_index} from security.')
         await self.move_card(ws, f'mySecurity{card_index}', 'myReveal', target_card_id=card_id)
-        self.game['player2Reveal'].append(self.game['player2Security'].pop(0))
+        self.game['player2Reveal'].append(self.game['player2Security'].pop(card_index))
     
     async def security_check(self, ws, card_id):
         card_index = self.find_card_index_by_id_in_security(card_id)
         self.logger.info(f'Security check.')
         await self.move_card(ws, f'mySecurity{card_index}', 'myReveal', target_card_id=card_id)
-        self.game['player2Reveal'].append(self.game['player2Security'].pop(0))
+        self.game['player2Reveal'].append(self.game['player2Security'].pop(card_index))
 
     async def reveal_card_from_top_of_deck(self, ws, n_cards):
         self.logger.info(f'Revealing top {n_cards} from deck.')

--- a/ai/Waiter.py
+++ b/ai/Waiter.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime, timedelta
 from decouple import config
@@ -192,6 +193,15 @@ class Waiter:
         move_message_prefix = '[MOVE_CARD_TO_DECK]:'
         if message.startswith(move_message_prefix):
             self.process_move_to_deck_action(message.replace(move_message_prefix, '', 1))
+        shuffle_security_prefix = '【↻ Security Stack】'
+        if message.startswith('[UPDATE_OPPONENT]'):
+            updated_game = ''
+            while message.startswith('[UPDATE_OPPONENT]'):
+                updated_game += message.replace('[UPDATE_OPPONENT]:', '')
+                await self.bot.loaded_ping(ws)
+                message = await ws.recv()
+                self.logger.debug(f'Received: {message}')
+            await self.bot.update_opponent_game(ws, json.loads(updated_game))
         chat_message_prefix = f'[CHAT_MESSAGE]:{self.bot.opponent}﹕'
         message = message.replace(chat_message_prefix, '', 1).strip().lower()
         prefix = 'suspend'

--- a/ai/Waiter.py
+++ b/ai/Waiter.py
@@ -185,6 +185,9 @@ class Waiter:
             await self.reset_timestamp()
         if not await self.check_timestamp():
             return False
+        update_memory_prefix = '[UPDATE_MEMORY]'
+        if message.startswith(update_memory_prefix):
+            self.bot.game['memory'] = int(message.replace('[UPDATE_MEMORY]:', ''))
         move_message_prefix = '[MOVE_CARD]:'
         if message.startswith(move_message_prefix) and not self.ignore_next_move_action:
             self.process_move_action(message.replace(move_message_prefix, '', 1))

--- a/ai/Waiter.py
+++ b/ai/Waiter.py
@@ -190,7 +190,7 @@ class Waiter:
             self.process_move_action(message.replace(move_message_prefix, '', 1))
         elif self.ignore_next_move_action:
             self.ignore_next_move_action = False
-        move_message_prefix = '[MOVE_CARD_TO_DECK]:'
+        move_message_prefix = '[MOVE_CARD_TO_STACK]:'
         if message.startswith(move_message_prefix):
             self.process_move_to_deck_action(message.replace(move_message_prefix, '', 1))
         shuffle_security_prefix = '【↻ Security Stack】'

--- a/ai/Waiter.py
+++ b/ai/Waiter.py
@@ -166,6 +166,14 @@ class Waiter:
             return target_digimon['id'], n
         await self.send_invalid_command_message(ws)
         return False, False
+
+    async def filter_trash_from_deck_action(self, ws, message):
+        message = message.split(' ')
+        if len(message) == 2 and message[-1].isdigit():
+            n = int(message[-1])
+            return n
+        await self.send_invalid_command_message(ws)
+        return False
     
     async def reset_timestamp(self):
         self.timestamp = datetime.now()
@@ -270,7 +278,9 @@ class Waiter:
         prefix = 'trash top deck'
         prefix_with_delimiter = prefix.replace(' ', '_')
         if message.startswith(prefix) and len(self.bot.game['player2DeckField']) > 0:
-            await self.bot.trash_top_card_of_deck(ws)
+            n = await self.filter_trash_from_deck_action(ws, message.replace(prefix, prefix_with_delimiter))
+            if n:
+                await self.bot.trash_top_cards_of_deck(ws, n)
         prefix = 'play reveal'
         prefix_with_delimiter = prefix.replace(' ', '_')
         if message.startswith(prefix):

--- a/ai/card/BT12_073_Impmon_X_Antibody.py
+++ b/ai/card/BT12_073_Impmon_X_Antibody.py
@@ -40,12 +40,4 @@ class BT12_073_Impmon_X_Antibody(Card):
     async def inherited_when_attacking_once_per_turn(self, ws):
         await super().animate_effect(ws)
         await self.bot.send_message(ws, 'BT12-073 Impmon (X Antibody) inherited effect: I trash the top 3 cards of my deck.')
-        trashed_cards = []
-        for i in range(2):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
-        await self.bot.when_card_is_trashed_from_deck(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 3)

--- a/ai/card/BT12_085_Beelzemon_X_Antibody.py
+++ b/ai/card/BT12_085_Beelzemon_X_Antibody.py
@@ -16,4 +16,4 @@ class BT12_085_Beelzemon_X_Antibody(Card):
                 await self.bot.waiter.wait_for_actions(ws)
     async def on_deletion_effect(self, ws):
         await self.bot.send_message(ws, f"Beelzemon (X Antibody) [On Deletion] effect:")
-        self.bot.bt12_085_beelzemon_x_antibody_on_deletion_strategy(ws)
+        await self.bot.bt12_085_beelzemon_x_antibody_on_deletion_strategy(ws)

--- a/ai/card/BT2_068_Impmon.py
+++ b/ai/card/BT2_068_Impmon.py
@@ -9,12 +9,4 @@ class BT2_068_Impmon(Card):
     ## TODO: Make optional to trash up to three cards
     async def on_deletion_effect(self, ws):
         await self.bot.send_message(ws, 'BT2-068 Impmon [On Deletion] effect: I trash 3 cards from top of deck.')
-        trashed_cards = []
-        for i in range(3):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
-        await self.bot.when_card_is_trashed_from_deck(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 3)

--- a/ai/card/EX2_039_Impmon.py
+++ b/ai/card/EX2_039_Impmon.py
@@ -14,15 +14,7 @@ class EX2_039_Impmon(Card):
     ## TODO: Make optional to trash up to three cards
     async def when_trashed_effect(self, ws):
         await self.bot.send_message(ws, f"EX2-039 Impmon effect when trashed: I trash 3 cards from top of deck.")
-        trashed_cards = []
-        for i in range(3):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
-        await self.bot.when_card_is_trashed_from_deck(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 3)
 
     async def on_play_effect(self, ws):
         await super().animate_effect(ws)

--- a/ai/card/EX2_044_Beelzemon.py
+++ b/ai/card/EX2_044_Beelzemon.py
@@ -14,7 +14,7 @@ class EX2_044_Beelzemon(Card):
 
     async def when_digivolving_when_attacking_effect(self, ws):
         await super().animate_effect(ws)
-        await self.bot.trash_top_cards_of_deck(ws, 3)
+        await self.bot.trash_top_cards_of_deck(ws, 2)
         await self.bot.ex2_044_beelzemon_when_digivolving_when_attacking_strategy(ws)
 
     ## TODO: Can target strategy to 

--- a/ai/card/EX2_044_Beelzemon.py
+++ b/ai/card/EX2_044_Beelzemon.py
@@ -14,16 +14,8 @@ class EX2_044_Beelzemon(Card):
 
     async def when_digivolving_when_attacking_effect(self, ws):
         await super().animate_effect(ws)
-        trashed_cards = []
-        for i in range(3):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 3)
         await self.bot.ex2_044_beelzemon_when_digivolving_when_attacking_strategy(ws)
-        await self.bot.when_card_is_trashed_from_deck(ws)
 
     ## TODO: Can target strategy to 
     async def when_digivolving_effect(self, ws):

--- a/ai/card/ST14_01_Yaamon.py
+++ b/ai/card/ST14_01_Yaamon.py
@@ -8,15 +8,7 @@ class ST14_01_Yaamon(Card):
 
     async def inherited_when_attacking_once_per_turn(self, ws):
         await super().animate_effect(ws)
-        trashed_cards = []
         attacking_digimon = self.extra_args['attacking_digimon']
         if 'Evil' in attacking_digimon['digiType'] or 'Wizard' in attacking_digimon['digiType'] or 'Demon Lord' in attacking_digimon['digiType']:
             await self.bot.send_message(ws, 'ST14-01 Yaamon inherited effect: I trash the top 2 cards of my deck.')
-            for i in range(2):
-                if len(self.bot.game['player2DeckField']) > 0:
-                    time.sleep(0.3)
-                    trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-            for trashed_card in trashed_cards:
-                card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-                await card_obj.when_trashed_effect(ws)
-            await self.bot.when_card_is_trashed_from_deck(ws)
+            await self.bot.trash_top_cards_of_deck(ws, 2)

--- a/ai/card/ST14_06_Witchmon.py
+++ b/ai/card/ST14_06_Witchmon.py
@@ -9,12 +9,4 @@ class ST14_06_Witchmon(Card):
     async def when_digivolving_effect(self, ws):
         await super().animate_effect(ws)
         await self.bot.send_message(ws, 'ST14-06 Witchmon [When Digivolving] effect: I trash the top 3 cards of my deck.')
-        trashed_cards = []
-        for i in range(3):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
-        await self.bot.when_card_is_trashed_from_deck(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 3)

--- a/ai/card/ST14_07_Baalmon.py
+++ b/ai/card/ST14_07_Baalmon.py
@@ -11,13 +11,5 @@ class ST14_07_Baalmon(Card):
         await super().animate_effect(ws)
         await self.bot.send_message(ws, 'ST14-07 Baalmon [When Digivolving] effect: I trash the top 3 cards of my deck.')
         await self.bot.send_message(ws, 'ST14-07 Baalmon [When Digivolving] effect: Gains [On Deletion] If there are 10 or more cards in your trash, you may play 1 Beelzemon from trash without paying the cost until the end of opponent\'s turn.')
-        trashed_cards = []
-        for i in range(3):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
-        await self.bot.when_card_is_trashed_from_deck(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 3)
         self.bot.gained_baalmon_effect.add(self.extra_args['card_id'])

--- a/ai/card/ST14_08_Beelzemon.py
+++ b/ai/card/ST14_08_Beelzemon.py
@@ -12,13 +12,7 @@ class ST14_08_Beelzemon(Card):
         await super().animate_effect(ws)
         trashed_cards = []
         await self.bot.send_message(ws, 'ST14-08 Beelzemon [When Digivolving] effect: I trash the top 4 cards of my deck.')
-        for i in range(4):
-            if len(self.bot.game['player2DeckField']) > 0:
-                time.sleep(0.3)
-                trashed_cards.append(await self.bot.trash_top_card_of_deck(ws))
-        for trashed_card in trashed_cards:
-            card_obj = self.bot.card_factory.get_card(trashed_card['uniqueCardNumber'], card_id=trashed_card['id'])
-            await card_obj.when_trashed_effect(ws)
+        await self.bot.trash_top_cards_of_deck(ws, 4)
     
     async def all_turns_effect(self, ws):
         await super().animate_effect(ws)


### PR DESCRIPTION
Refactored how trashing cards from top of deck works and fixed relative bugs.
Shuffling of security does not break bot anymore.
Beelzemon X on deletion effect triggers correctly now
Fixed issue when player moves cards to deck.
Fixed bug where bot ignores player setting memory while waiting.